### PR TITLE
add mass messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,13 @@ local.settings.json
 node_modules
 dist
 
+__blobstorage__
+__queuestorage__
+__azurite_db_blob__.json
+__azurite_db_blob_extent__.json
+__azurite_db_queue__.json
+__azurite_db_queue_extent__.json
+
 # Local python packages
 .python_packages/
 

--- a/MassMessage/Scripts/sendMessage.ts
+++ b/MassMessage/Scripts/sendMessage.ts
@@ -1,0 +1,27 @@
+import { AzureFunction, Context, HttpRequest } from '@azure/functions';
+import * as twilio from 'twilio';
+import qs from 'qs';
+import {IUserState} from '../../ReceiveMessage/models/UserState';
+import MongoConnect from '../../ReceiveMessage/Scripts/db';
+
+
+const MessagingResponse = twilio.twiml.MessagingResponse;
+const accountSid = process.env.TWILIO_ACCOUNT_SID;
+const authToken = process.env.TWILIO_AUTH_TOKEN;
+const client = require('twilio')(accountSid, authToken);
+
+//will need to update functions when phone number is not directly stored
+
+export const sendCompletedMessage = async function (id : string, date : string, modules : Array<number>) {
+    await MongoConnect();
+    const message = `Hi, you completed module(s) ${modules.join()} on ${date}. Pls respond.`;
+
+    await client.messages.create({body: message, from: '+13159300241', to: id});
+};
+
+export const sendInactiveMessage = async function (id : string, date : string) {
+    await MongoConnect();
+    const message = `Hi, you haven't had any activity since ${date}. Pls respond.`;
+
+    await client.messages.create({body: message, from: '+13159300241', to: id});
+};

--- a/MassMessage/function.json
+++ b/MassMessage/function.json
@@ -1,0 +1,11 @@
+{
+  "bindings": [
+    {
+      "name": "myTimer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 0 10 * * *"
+    }
+  ],
+  "scriptFile": "../dist/MassMessage/index.js"
+}

--- a/MassMessage/function.json
+++ b/MassMessage/function.json
@@ -4,7 +4,7 @@
       "name": "myTimer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 10 * * *"
+      "schedule": "0 0 8 * * *"
     }
   ],
   "scriptFile": "../dist/MassMessage/index.js"

--- a/MassMessage/index.ts
+++ b/MassMessage/index.ts
@@ -49,13 +49,13 @@ const messageCompletedUsers = async function (date:Date, context: Context) {
     prevDay.setDate(prevDay.getDate()-1);
 
     const allUsers = await UserState.find({
-        completedTimes: {
+        moduleCompletionTime: {
             $gte: prevDay,
             $lt: date
         }
     });
     allUsers.forEach(user => {
-        const modules = user.completedTimes.map((time, index) => {
+        const modules = user.moduleCompletionTime.map((time, index) => {
             if (time >= prevDay && time < date) { // module was completed 2 months ago
                 return index;
             } else {

--- a/MassMessage/index.ts
+++ b/MassMessage/index.ts
@@ -1,0 +1,14 @@
+import { AzureFunction, Context } from "@azure/functions"
+
+//the timer is currently set to run everyday at 10AM, can be changed in function.json
+const timerTrigger: AzureFunction = async function (context: Context, myTimer: any): Promise<void> {
+    var timeStamp = new Date().toISOString();
+    
+    if (myTimer.isPastDue)
+    {
+        context.log('Timer function is running late!');
+    }
+    context.log('Timer trigger function ran!', timeStamp);   
+};
+
+export default timerTrigger;

--- a/MassMessage/index.ts
+++ b/MassMessage/index.ts
@@ -1,6 +1,10 @@
 import { AzureFunction, Context } from "@azure/functions"
 
-//the timer is currently set to run everyday at 10AM, can be changed in function.json
+import { Schema } from 'mongoose';
+import UserState from '../ReceiveMessage/models/UserState';
+import MongoConnect from '../ReceiveMessage/Scripts/db';
+
+//the timer is currently set to run everyday at our 9AM (10AM in guatemala), can be changed in function.json
 const timerTrigger: AzureFunction = async function (context: Context, myTimer: any): Promise<void> {
     var timeStamp = new Date().toISOString();
     
@@ -8,7 +12,44 @@ const timerTrigger: AzureFunction = async function (context: Context, myTimer: a
     {
         context.log('Timer function is running late!');
     }
-    context.log('Timer trigger function ran!', timeStamp);   
+    context.log('Timer trigger function ran!', timeStamp);
+
+    await MongoConnect();
+
+    let date = new Date();
+    //avoiding the use of times
+    date.setHours(0);
+    date.setMinutes(0);
+    date.setSeconds(0);
+    date.setMilliseconds(0);
+    
+    //set to two months ago
+    date.setMonth(date.getMonth() - 2);
+
+    const inactive = await findInactiveUsers(date);
+    context.log(inactive);
+    const catchup = await findCompletedUsers(date);
+    context.log(catchup)
 };
+
+//gets users where last activity was exactly 2 months ago
+const findInactiveUsers = async function(date:Date) {
+    return UserState.find({
+        lastActivity: date
+    });
+}
+
+//gets users where they completed a module 2 months ago
+const findCompletedUsers = async function (date:Date) {
+    let prevDay = new Date(date.toDateString());
+    prevDay.setDate(prevDay.getDate()-1);
+
+    return UserState.find({
+        completedTimes: {
+            $gte: prevDay,
+            $lte: date
+        }
+    });
+}
 
 export default timerTrigger;

--- a/MassMessage/readme.md
+++ b/MassMessage/readme.md
@@ -1,0 +1,11 @@
+# TimerTrigger - TypeScript
+
+The `TimerTrigger` makes it incredibly easy to have your functions executed on a schedule. This sample demonstrates a simple use case of calling your function every 5 minutes.
+
+## How it works
+
+For a `TimerTrigger` to work, you provide a schedule in the form of a [cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression)(See the link for full details). A cron expression is a string with 6 separate expressions which represent a given schedule via patterns. The pattern we use to represent every 5 minutes is `0 */5 * * * *`. This, in plain text, means: "When seconds is equal to 0, minutes is divisible by 5, for any hour, day of the month, month, day of the week, or year".
+
+## Learn more
+
+<TODO> Documentation

--- a/ReceiveMessage/models/UserState.ts
+++ b/ReceiveMessage/models/UserState.ts
@@ -4,20 +4,18 @@ import {IMessage} from './ChatbotMessage';
 export interface IUserState extends Document {
     userId: string;
     currMessage: IMessage['_id'];
-    completedModules: Array <number>;
     split: boolean;
     lowData: boolean;
-    completedTimes: Array <Date>;
+    moduleCompletionTime: Array <Date>;
     lastActivity: Date;
 }
 
 const UserStateSchema = new Schema({
     userId: { type: String, required: true, unique: true },
     currMessage: { type: Schema.Types.ObjectId, ref: 'ChatbotMessage', required: true },
-    completedModules: {type: Array, "default": []},
     split: { type: Boolean, required: false },
     lowData: { type: Boolean},
-    completedTimes: {type: Array, "default": [null, null, null, null, null]},
+    moduleCompletionTime: {type: Array, "default": [null, null, null, null, null]},
     lastActivity: {type: Date}
 });
 

--- a/ReceiveMessage/models/UserState.ts
+++ b/ReceiveMessage/models/UserState.ts
@@ -1,7 +1,7 @@
 import mongoose, { Schema, Document } from 'mongoose';
 import {IMessage} from './ChatbotMessage';
 
-export interface State extends Document {
+export interface IUserState extends Document {
     userId: string;
     currMessage: IMessage['_id'];
     completedModules: Array <number>;
@@ -21,4 +21,4 @@ const UserStateSchema = new Schema({
     lastActivity: {type: Date}
 });
 
-export default mongoose.model<State>("UserState", UserStateSchema);
+export default mongoose.model<IUserState>("UserState", UserStateSchema);

--- a/ReceiveMessage/models/UserState.ts
+++ b/ReceiveMessage/models/UserState.ts
@@ -7,7 +7,8 @@ export interface State extends Document {
     completedModules: Array <number>;
     split: boolean;
     lowData: boolean;
-    completedTimes: Array <Schema.Types.Date>;
+    completedTimes: Array <Date>;
+    lastActivity: Date;
 }
 
 const UserStateSchema = new Schema({
@@ -17,6 +18,7 @@ const UserStateSchema = new Schema({
     split: { type: Boolean, required: false },
     lowData: { type: Boolean},
     completedTimes: {type: Array, "default": [null, null, null, null, null]},
+    lastActivity: {type: Date}
 });
 
 export default mongoose.model<State>("UserState", UserStateSchema);


### PR DESCRIPTION
Changes for summary:
1. Added a timer trigger azure function. This is currently set to run once a day, at EST 8am or 9am in Guatemala
2. Added some extra files to the git ignore that I think are generated by azurite (storage emulator)
3. Added ability to text users when they meet a criteria
4. Changed UserState Interface name from "State" to "IUserState" so that it made more sense when importing
5. Removed completedModules from UserState. Renamed completedTimes to moduleCompletionTime

Notes for myself/future:
1. Code will need to be updated when the phone number is no longer just stored as the userId
2. Need twilio authentication to be updated in the .env (talked to matt about this)
3. Slight update on how to run project which is just running `azurite` in another terminal
4. Not sure if time zone will have an impact on how dates are stored? Don't think it does and if it does the impact should be minimal with current criteria

Results from some testing (changed the phone numbers in MongoDB so it just texted me)
Users that haven't been active for exactly 2 months:
![image](https://user-images.githubusercontent.com/52008605/110195455-1959fd00-7e0b-11eb-877e-ac2d4d069785.png)

Users that have completed modules exactly 2 months ago
![image](https://user-images.githubusercontent.com/52008605/110195462-270f8280-7e0b-11eb-9f63-19910b2872e5.png)
